### PR TITLE
Retrieve properties in datasource-mysql activator

### DIFF
--- a/db/datasource-mysql/src/main/java/net/lr/db/datasource/Activator.java
+++ b/db/datasource-mysql/src/main/java/net/lr/db/datasource/Activator.java
@@ -28,7 +28,7 @@ public class Activator implements BundleActivator {
         @SuppressWarnings("rawtypes")
         private String getString(String key, Dictionary properties) {
             Object value = properties.get(key);
-            return (value == null || !(value instanceof String)) ? "" : key;
+            return (value == null || !(value instanceof String)) ? "" : value;
             
         }
 


### PR DESCRIPTION
The getString method of the datasource-mysql activator should return the property value instead of the property key in order to allow configuring the datasource through properties.
