### PR TITLE
cxf/personservice-rest: Updated Readme and webui references

### DIFF
--- a/cxf/personservice-rest/ReadMe.txt
+++ b/cxf/personservice-rest/ReadMe.txt
@@ -38,7 +38,7 @@ Download Apache Karaf here: http://karaf.apache.org/index/community/download.htm
 
 Karaf 3, 4
 feature:repo-add cxf 3.1.0
-feature:install cxf-jaxrs http
+feature:install cxf-jaxrs http http-whiteboard
 
 install -s mvn:net.lr.tutorial.karaf.cxf.personrest/personrest-model/1.0-SNAPSHOT
 install -s mvn:net.lr.tutorial.karaf.cxf.personrest/personrest-server/1.0-SNAPSHOT

--- a/cxf/personservice-rest/webui/src/main/java/net/lr/tutorial/karaf/cxf/personrest/webui/PersonServlet.java
+++ b/cxf/personservice-rest/webui/src/main/java/net/lr/tutorial/karaf/cxf/personrest/webui/PersonServlet.java
@@ -29,7 +29,7 @@ public class PersonServlet extends HttpServlet {
         }
         os.println("</table>");
         os.println("<h2>Add Person</h2>");
-        os.println("<form name='input' action='/personui' method='post'>");
+        os.println("<form name='input' action='/personuirest' method='post'>");
         os.println("<table>");
         os.println("<tr><td>Id</td><td><input type='text' name='id'/></td></tr>");
         os.println("<tr><td>Name</td><td><input type='text' name='name'/></td></tr>");
@@ -50,7 +50,7 @@ public class PersonServlet extends HttpServlet {
         person.setName(name);
         person.setUrl(url);
         personService.addPerson(person );
-        resp.sendRedirect("/personui");
+        resp.sendRedirect("/personuirest");
     }
 
     public void setPersonService(PersonService personService) {


### PR DESCRIPTION
* Updated ReadMe.txt to install feature `http-whiteboard` otherwise PersonServlet would not be registered.
* `webui/PersonServlet` is referencing the jaxws project personservice endpoint. Updated both the redirect and post to `/personuirest`.