### PR TITLE
Change some karaf commands

### DIFF
--- a/configadmin/readme.txt
+++ b/configadmin/readme.txt
@@ -17,5 +17,5 @@ h2. Installation
 
 There is only an automated installation for the blueprint case.
 
-features:addurl mvn:net.lr.tutorial.configadmin/configadmin-features/1.0/xml
-features:install  tutorial-configadmin
+feature:repo-add mvn:net.lr.tutorial.configadmin/configadmin-features/1.0/xml
+feature:install  tutorial-configadmin


### PR DESCRIPTION
I'm using karaf 4.1.1 to do the practice in your tutorial. Perhaps because the version of karaf I use has changed some thing, if I use `features:addurl` or `features:install`, it will tell me command not found, but when I use `feature:repo-add` and `feature:install` it works fine.